### PR TITLE
Fix 'Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>' issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY . /app
 
 WORKDIR /app
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
[CodeFactor](https://www.codefactor.io/repository/github/andreaspb/sd-sem1-testing) found an issue: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`

It's currently on:
[Dockerfile:7](https://www.codefactor.io/repository/github/andreaspb/sd-sem1-testing/source/master/Dockerfile#L7)